### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-vocals.com


### PR DESCRIPTION
This test was to see what'd happen if CNAME had a URL that someone else has. I was hoping it'd fallback to [vocals.github.io](https://vocals.github.io) but no dice. It redirected to the CNAME URL instead. Reason for this was to learn what'd happen if a custom domain lapsed.